### PR TITLE
Increment the JWT Token expiration time to 2 weeks

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -319,6 +319,6 @@ Devise.setup do |config|
     jwt.revocation_requests = [
       ['DELETE', %r{^/logout$}]
     ]
-    jwt.expiration_time = 30.minutes.to_i
+    jwt.expiration_time = 2.weeks.to_i
   end
 end


### PR DESCRIPTION
## In this PR:
- Increased the JWT token expiration time
When too much time passesv(30 min) and a logged in user tries to navigate to other pages, the app redirects the user to the Home page and the only solution is to logout and sign in again. 
To avoid this happening too often I increased the JWT token expiration time to 2 weeks
